### PR TITLE
Add namespace to `kustomization.yaml` to reduce manual steps to recreate px-finagle demo

### DIFF
--- a/kubernetes/docker-default-networkpolicy.yaml
+++ b/kubernetes/docker-default-networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  name: docker-default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              io.kompose.network/docker-default: "true"
+  podSelector:
+    matchLabels:
+      io.kompose.network/docker-default: "true"

--- a/kubernetes/finagle-client-deployment.yaml
+++ b/kubernetes/finagle-client-deployment.yaml
@@ -3,12 +3,11 @@ kind: Deployment
 metadata:
   annotations:
     kompose.cmd: kompose convert -f ../docker/docker-compose.yml
-    kompose.version: 1.26.1 (a9d05d509)
+    kompose.version: 1.28.0 (c4137012e)
   creationTimestamp: null
   labels:
     io.kompose.service: finagle-client
   name: finagle-client
-  namespace: px-finagle
 spec:
   replicas: 1
   selector:
@@ -19,9 +18,10 @@ spec:
     metadata:
       annotations:
         kompose.cmd: kompose convert -f ../docker/docker-compose.yml
-        kompose.version: 1.26.1 (a9d05d509)
+        kompose.version: 1.28.0 (c4137012e)
       creationTimestamp: null
       labels:
+        io.kompose.network/docker-default: "true"
         io.kompose.service: finagle-client
     spec:
       containers:

--- a/kubernetes/finagle-server-deployment.yaml
+++ b/kubernetes/finagle-server-deployment.yaml
@@ -3,12 +3,11 @@ kind: Deployment
 metadata:
   annotations:
     kompose.cmd: kompose convert -f ../docker/docker-compose.yml
-    kompose.version: 1.26.1 (a9d05d509)
+    kompose.version: 1.28.0 (c4137012e)
   creationTimestamp: null
   labels:
     io.kompose.service: finagle-server
   name: finagle-server
-  namespace: px-finagle
 spec:
   replicas: 1
   selector:
@@ -19,9 +18,10 @@ spec:
     metadata:
       annotations:
         kompose.cmd: kompose convert -f ../docker/docker-compose.yml
-        kompose.version: 1.26.1 (a9d05d509)
+        kompose.version: 1.28.0 (c4137012e)
       creationTimestamp: null
       labels:
+        io.kompose.network/docker-default: "true"
         io.kompose.service: finagle-server
     spec:
       containers:

--- a/kubernetes/finagle-server-service.yaml
+++ b/kubernetes/finagle-server-service.yaml
@@ -3,12 +3,11 @@ kind: Service
 metadata:
   annotations:
     kompose.cmd: kompose convert -f ../docker/docker-compose.yml
-    kompose.version: 1.26.1 (a9d05d509)
+    kompose.version: 1.28.0 (c4137012e)
   creationTimestamp: null
   labels:
     io.kompose.service: finagle-server
   name: finagle-server
-  namespace: px-finagle
 spec:
   ports:
     - name: "9992"

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: px-finagle
 resources:
   - kubernetes/namespace.yaml
   - kubernetes/finagle-client-deployment.yaml


### PR DESCRIPTION
The instructions in this repo's README required some hidden steps in order to recreate the [px-finagle demo manifest](https://github.com/pixie-io/pixie/blob/8111b1c558a41dfb20454c8dfbfb5f61538c5114/demos/finagle/finagle.yaml). When `kompose` is run it erases the `namespace: px-finagle` defined in each deployment and service config in the `kubernetes/` directory.

This change instructs `kustomize` to do the namespace annotation, so the files don't need to be manually changed after kustomization.

## Testing done
- Ran `kompose` and `kustomize` and diffed it against the pixie cli manifests ([P391](https://phab.corp.pixielabs.ai/P391))
- Validated that without this change the resulting manifests are missing the `px-finagle` namespace ([P392](https://phab.corp.pixielabs.ai/P392))